### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![travis ci build state](https://travis-ci.org/JasonAUnrein/Persistent-Pineapple.svg?branch=master)](https://travis-ci.org/JasonAUnrein/Persistent-Pineapple)
 [![rtd state](https://readthedocs.org/projects/persistent-pineapple/badge/?version=latest)](https://readthedocs.org/projects/persistent-pineapple/?badge=latest)
 [![Coverage Status](https://img.shields.io/coveralls/JasonAUnrein/Persistent-Pineapple.svg)](https://coveralls.io/r/JasonAUnrein/Persistent-Pineapple)
-[![Version](https://pypip.in/v/Persistent-Pineapple/badge.png)](https://pypi.python.org/pypi/Persistent-Pineapple)
-[![Downloads](https://pypip.in/d/Persistent-Pineapple/badge.png)](https://pypi.python.org/pypi/Persistent-Pineapple)
+[![Version](https://img.shields.io/pypi/v/Persistent-Pineapple.svg
+[![Downloads](https://img.shields.io/pypi/dm/Persistent-Pineapple.svg
 
 ## Introduction
 Persistent Pineapple provides a simple interface to save settings for

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 [![travis ci build state](https://travis-ci.org/JasonAUnrein/Persistent-Pineapple.svg?branch=master)](https://travis-ci.org/JasonAUnrein/Persistent-Pineapple)
 [![rtd state](https://readthedocs.org/projects/persistent-pineapple/badge/?version=latest)](https://readthedocs.org/projects/persistent-pineapple/?badge=latest)
 [![Coverage Status](https://img.shields.io/coveralls/JasonAUnrein/Persistent-Pineapple.svg)](https://coveralls.io/r/JasonAUnrein/Persistent-Pineapple)
-[![Version](https://img.shields.io/pypi/v/Persistent-Pineapple.svg
-[![Downloads](https://img.shields.io/pypi/dm/Persistent-Pineapple.svg
+[![Version](https://img.shields.io/pypi/v/Persistent-Pineapple.svg)](https://pypi.python.org/pypi/Persistent-Pineapple)
 
 ## Introduction
 Persistent Pineapple provides a simple interface to save settings for


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20persistent-pineapple))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `persistent-pineapple`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.